### PR TITLE
Bugfix to use german Umlauts within Loxone Config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # force platfrom=linux/386 because alpine x64 doesn't support wine32 and LoxoneConfig is win32
 FROM --platform=linux/386 jlesage/baseimage-gui:alpine-3.18-v4.5
 
-RUN add-pkg wine wget xterm cabextract
+RUN add-pkg wine wget xterm cabextract xkeyboard-config setxkbmap
 RUN wget -O /usr/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks && \
   chmod +x /usr/bin/winetricks
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # force platfrom=linux/386 because alpine x64 doesn't support wine32 and LoxoneConfig is win32
 FROM --platform=linux/386 jlesage/baseimage-gui:alpine-3.18-v4.5
 
+ARG XLANG=de
+
 RUN add-pkg wine wget xterm cabextract xkeyboard-config setxkbmap
 RUN wget -O /usr/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks && \
   chmod +x /usr/bin/winetricks

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ services:
       - DISPLAY_HEIGHT=1080
       - HOME=/config/
       - WINEPREFIX=/config/wine
+	  - XLANG=de
     volumes:
       - "./config:/config:rw"
 ```
@@ -81,7 +82,7 @@ of this parameter has the format `<VARIABLE_NAME>=<VALUE>`.
 |`DISPLAY_HEIGHT`| Height (in pixels) of the application's window. | `768` |
 |`SECURE_CONNECTION`| When set to `1`, an encrypted connection is used to access the application's GUI (either via web browser or VNC client).  See the [Security](#security) section for more details. | `0` |
 |`VNC_PASSWORD`| Password needed to connect to the application's GUI.  See the [VNC Password](#vnc-password) section for more details. | (unset) |
-
+|`XLANG`| Keyboard map to be used by XVNC/Loxone Config. Use this to set specific keyboard maps via setxkbmap. See the [keyboard maps](#keyboard-maps) section for more details. | `de` |
 
 ### Ports
 
@@ -96,6 +97,21 @@ container cannot be changed, but you are free to use any port on the host side.
 | 5900 | Optional | Port used to access the application's GUI via the VNC protocol.  Optional if no VNC client is used. |
 
 **NOTE**: For additional security you should bind to localhost only to prevent other devices in your network from accessing the Loxone Config. `127.0.0.1:5800:5800` instead of `5800:5800` inside `docker-compose.yml`.
+
+### Keyboard maps
+
+Keyboard maps are set via setxkbmap. See the [setxkbmap configuration options](https://gist.github.com/jatcwang/ae3b7019f219b8cdc6798329108c9aee) section "layout" for more details.
+
+Common keyboard maps are:
+
+| map | Language | Default |
+|-----|----------| ------- |
+| us | English (US) | - |
+| en | English | - |
+| at | German (Austria) | - |
+| ch | German (Switzerland) | - |
+| de | German | yes |
+| fr | French | - |
 
 ## User/Group IDs
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ services:
       - DISPLAY_HEIGHT=1080
       - HOME=/config/
       - WINEPREFIX=/config/wine
-	  - XLANG=de
+      - XLANG=de
     volumes:
       - "./config:/config:rw"
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - HOME=/config/
       - WINEPREFIX=/config/wine
       - WINEARCH=win32
+	  - XLANG=de
     volumes:
       - "./config:/config:rw"
       - "./config/Loxone:/config/wine/drive_c/users/app/Documents/Loxone:rw"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - HOME=/config/
       - WINEPREFIX=/config/wine
       - WINEARCH=win32
-	  - XLANG=de
+      - XLANG=de
     volumes:
       - "./config:/config:rw"
       - "./config/Loxone:/config/wine/drive_c/users/app/Documents/Loxone:rw"

--- a/startapp.sh
+++ b/startapp.sh
@@ -5,6 +5,6 @@ if [ ! -d "/config/wine/drive_c/Program Files/Loxone" ]; then
 fi
 
 export WINEDEBUG=-all
-setxkbmap de 
+setxkbmap $XLANG
 #exec xterm
 exec wine "/config/wine/drive_c/Program Files/Loxone/LoxoneConfig/LoxoneConfig.exe"

--- a/startapp.sh
+++ b/startapp.sh
@@ -5,5 +5,6 @@ if [ ! -d "/config/wine/drive_c/Program Files/Loxone" ]; then
 fi
 
 export WINEDEBUG=-all
+setxkbmap de 
 #exec xterm
 exec wine "/config/wine/drive_c/Program Files/Loxone/LoxoneConfig/LoxoneConfig.exe"


### PR DESCRIPTION
Added new packages to configure keyboard map for XVNC
Added call to start script
Added docker argument/env variable to set keyboard map at runtime
Updated documentation