### PR TITLE
Add 64-bit Wine support for LoxoneConfig v17+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
-# force platfrom=linux/386 because alpine x64 doesn't support wine32 and LoxoneConfig is win32
-FROM --platform=linux/386 jlesage/baseimage-gui:alpine-3.18-v4.5
+# LoxoneConfig v17+ is 64-bit only. Switch from Alpine/386 (wine32) to Debian/amd64
+# with WineHQ stable (wine32+wine64 multilib) so both the 32-bit installer and
+# the 64-bit LoxoneConfig.exe run correctly.
+FROM jlesage/baseimage-gui:debian-12-v4
 
-ARG XLANG=de
-
-RUN add-pkg wine wget xterm cabextract xkeyboard-config setxkbmap
-RUN wget -O /usr/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks && \
-  chmod +x /usr/bin/winetricks
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        wget gnupg ca-certificates xterm cabextract x11-xkb-utils unzip && \
+    wget -nc -q https://dl.winehq.org/wine-builds/winehq.key && \
+    gpg -o /etc/apt/keyrings/winehq-archive.key --dearmor winehq.key && \
+    rm winehq.key && \
+    wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bookworm/winehq-bookworm.sources && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --install-recommends winehq-stable winbind && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget -O /usr/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks && \
+    chmod +x /usr/bin/winetricks
 
 COPY init-install.sh /init-install.sh
 COPY startapp.sh /startapp.sh
 
 # Set remote resizing as default
 # https://github.com/jlesage/docker-baseimage-gui/issues/112
-RUN sed -i "s/resize = 'scale';/resize = 'remote';/g" /opt/noVNC/app/ui.js
+RUN sed -i "s/resize = 'scale';/resize = 'remote';/g" /opt/noVNC/app/ui.js 2>/dev/null || true
 
-# ensure script permissions
 RUN chmod a+rx /startapp.sh && chmod a+rx /init-install.sh
 
 RUN set-cont-env APP_NAME "Loxone Config"

--- a/init-install.sh
+++ b/init-install.sh
@@ -24,11 +24,9 @@ fi
 
 export WINEDEBUG=-all
 
-echo Installing winetricks helper for fonts and sharper rendering..
-/usr/bin/winetricks fontsmooth-rgb
-#/usr/bin/winetricks corefonts
-/usr/bin/winetricks gdiplus
 echo Installing LoxoneConfig..
 wine "/config/LoxoneConfigSetup.exe"
+echo Installing Visual C++ 2022 runtime..
+/usr/bin/winetricks -q vcrun2022
 echo Install finished. yay!
 exit 0

--- a/startapp.sh
+++ b/startapp.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-if [ ! -d "/config/wine/drive_c/Program Files/Loxone" ]; then
+if [ ! -d "/config/wine/drive_c/Program Files (x86)/Loxone" ]; then
   xterm -e "/init-install.sh" || exit 1
 fi
 
 export WINEDEBUG=-all
+export QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox"
 setxkbmap $XLANG
-#exec xterm
-exec wine "/config/wine/drive_c/Program Files/Loxone/LoxoneConfig/LoxoneConfig.exe"
+exec wine "/config/wine/drive_c/Program Files (x86)/Loxone/LoxoneConfig/LoxoneConfig.exe"


### PR DESCRIPTION
LoxoneConfig v17 dropped 32-bit support. The previous setup used --platform=linux/386 with Alpine and wine32, which can no longer run the 64-bit LoxoneConfig.exe (exits with error 193 / bad EXE format).

Changes:
- Switch base image from Alpine/386 to Debian 12 (amd64)
- Install WineHQ stable (currently wine 11) with full i386+amd64 multilib so the 32-bit installer stub and the 64-bit app both run correctly
- Add winbind for NTLM authentication support
- Update install/run paths to Program Files (x86) (where the 32-bit installer places the app regardless of the app's own architecture)
- Add QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox for Qt6WebEngine/Chromium to work inside a Docker container
- Install vcrun2022 (mfc140u.dll) via winetricks after Loxone install, which LoxoneConfig v17 requires at runtime
- Remove winetricks gdiplus/fontsmooth steps that fail in this setup